### PR TITLE
feat(feedback-loops): Sprint 1 - Interactive Diagnostic

### DIFF
--- a/.claude/rules/06-sigil-taste.md
+++ b/.claude/rules/06-sigil-taste.md
@@ -16,6 +16,63 @@ All signals go to `grimoires/sigil/taste.md`. Append-only. Human-readable.
 
 Modifications weight 5x because corrections teach more than silent acceptance.
 
+## Signal Schema (YAML Frontmatter)
+
+Each signal is logged with structured YAML frontmatter for machine parsing:
+
+```yaml
+---
+timestamp: "2026-01-19T14:32:00Z"
+signal: MODIFY
+source: cli                          # cli | toolbar | product
+component:
+  name: "ClaimButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+    confirmation: "required"
+  animation:
+    easing: "ease-out"
+    duration: "800ms"
+  material:
+    surface: "elevated"
+    shadow: "soft"
+    radius: "8px"
+diagnostic:                          # From diagnostic questions (Step 6b)
+  user_type: "mobile"
+  goal: "quickly check and claim rewards while commuting"
+  expected_feel: "snappy"
+  skipped: false
+change:
+  from: "800ms"
+  to: "500ms"
+learning:
+  inference: "Mobile users prefer faster timing for financial buttons"
+  recommendation: "Consider mobile-specific physics (faster timing)"
+---
+```
+
+## DiagnosticContext Schema
+
+When users provide feedback (MODIFY/REJECT), optional diagnostic questions capture context:
+
+| Field | Type | Values | Description |
+|-------|------|--------|-------------|
+| `user_type` | string | `power-user`, `casual`, `mobile`, `first-time`, custom | Who is the end user |
+| `goal` | string | free text | What the user was trying to accomplish |
+| `expected_feel` | string | `instant`, `snappy`, `deliberate`, `trustworthy`, custom | Desired interaction feel |
+| `skipped` | boolean | `true`, `false` | Whether user skipped diagnostics |
+
+**Source Field**:
+| Source | Description |
+|--------|-------------|
+| `cli` | Signal from Claude Code /craft command |
+| `toolbar` | Signal from Sigil Toolbar browser extension |
+| `product` | Signal from product-embedded feedback widget |
+
 ## Reading Taste
 
 At /craft time, read `grimoires/sigil/taste.md` and look for patterns:
@@ -50,30 +107,124 @@ Physics: [what was generated]
 
 If `grimoires/sigil/taste.md` has no signals yet, use physics defaults from the rules.
 
-## Example
+## Example: Enhanced Format
 
 ```markdown
-## 2026-01-13 14:32 | ACCEPT
-Component: ClaimButton
-Effect: Financial
-Physics: 800ms pessimistic, ease-out
+---
+timestamp: "2026-01-13T14:32:00Z"
+signal: ACCEPT
+source: cli
+component:
+  name: "ClaimButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+    confirmation: "required"
+  animation:
+    easing: "ease-out"
 ---
 
-## 2026-01-13 15:45 | MODIFY
-Component: WithdrawButton
-Effect: Financial
-Physics: 800ms pessimistic, ease-out
-Changed: 800ms → 500ms
-Learning: User prefers faster timing for financial buttons
+---
+timestamp: "2026-01-13T15:45:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "WithdrawButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+    confirmation: "required"
+  animation:
+    easing: "ease-out"
+diagnostic:
+  user_type: "power-user"
+  goal: "withdraw quickly during volatile market"
+  expected_feel: "snappy"
+  skipped: false
+change:
+  from: "800ms"
+  to: "500ms"
+learning:
+  inference: "Power users prefer faster timing for financial buttons"
+  recommendation: "Consider user-type-specific timing"
 ---
 
-## 2026-01-13 16:20 | MODIFY
-Component: StakeButton
-Effect: Financial
-Physics: 800ms pessimistic, ease-out
-Changed: 800ms → 500ms, ease-out → spring(400, 25)
-Learning: User prefers 500ms + spring for financial buttons
+---
+timestamp: "2026-01-13T16:20:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "StakeButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+  animation:
+    easing: "ease-out"
+diagnostic:
+  user_type: "mobile"
+  goal: "stake rewards while checking phone quickly"
+  expected_feel: "snappy"
+  skipped: false
+change:
+  from: "800ms, ease-out"
+  to: "500ms, spring(400, 25)"
+learning:
+  inference: "Mobile users prefer springs for tactile feedback"
+  recommendation: "Consider mobile-first animation physics"
+---
+
+---
+timestamp: "2026-01-13T17:00:00Z"
+signal: REJECT
+source: cli
+component:
+  name: "DeleteAccountButton"
+  effect: "Destructive"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "600ms"
+    confirmation: "required"
+diagnostic:
+  skipped: true
+rejection_reason: "Missing two-step confirmation for account deletion"
 ---
 ```
 
 After 3 MODIFY signals showing 500ms preference, /craft would generate financial buttons with 500ms by default and note: "Adjusted timing to 500ms based on taste log."
+
+## Example: Skipped Diagnostics
+
+When user skips diagnostic questions:
+
+```markdown
+---
+timestamp: "2026-01-13T18:00:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "TransferButton"
+  effect: "Financial"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+diagnostic:
+  skipped: true
+change:
+  from: "ease-out"
+  to: "spring(500, 30)"
+learning:
+  inference: "User prefers spring animations (no context available)"
+---
+```

--- a/grimoires/sigil/taste.md
+++ b/grimoires/sigil/taste.md
@@ -10,3 +10,129 @@ Accumulated preferences from usage. Read by `/craft` to inform generation.
 ---
 
 <!-- Signals appended below -->
+
+---
+timestamp: "2026-01-19T10:00:00Z"
+signal: ACCEPT
+source: cli
+component:
+  name: "ClaimButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+    confirmation: "required"
+  animation:
+    easing: "ease-out"
+    duration: "800ms"
+  material:
+    surface: "elevated"
+    shadow: "soft"
+    radius: "8px"
+---
+
+---
+timestamp: "2026-01-19T11:30:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "WithdrawButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+    confirmation: "required"
+  animation:
+    easing: "ease-out"
+diagnostic:
+  user_type: "mobile"
+  goal: "withdraw quickly while checking phone on commute"
+  expected_feel: "snappy"
+  skipped: false
+change:
+  from: "800ms"
+  to: "500ms"
+learning:
+  inference: "Mobile users prefer faster timing"
+  recommendation: "Consider mobile-specific physics (faster timing)"
+---
+
+---
+timestamp: "2026-01-19T12:15:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "StakeButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+  animation:
+    easing: "ease-out"
+diagnostic:
+  user_type: "power-user"
+  goal: "quickly stake multiple positions"
+  expected_feel: "snappy"
+  skipped: false
+change:
+  from: "800ms, ease-out"
+  to: "500ms, spring(400, 25)"
+learning:
+  inference: |
+    1. Significant timing preference: 800ms → 500ms (300ms faster)
+    2. Animation preference: ease-out → spring(400, 25)
+  recommendation: |
+    User prefers spring-based animations for tactile feedback AND
+    Consider adjusting base timing for Financial effects
+---
+
+---
+timestamp: "2026-01-19T13:00:00Z"
+signal: MODIFY
+source: cli
+component:
+  name: "TransferButton"
+  effect: "Financial"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "800ms"
+diagnostic:
+  skipped: true
+change:
+  from: "800ms"
+  to: "500ms"
+learning:
+  inference: "User prefers 500ms timing (no diagnostic context available)"
+---
+
+---
+timestamp: "2026-01-19T14:00:00Z"
+signal: REJECT
+source: cli
+component:
+  name: "DeleteAccountButton"
+  effect: "Destructive"
+  craft_type: "generate"
+physics:
+  behavioral:
+    sync: "pessimistic"
+    timing: "600ms"
+    confirmation: "required"
+diagnostic:
+  user_type: "casual"
+  goal: "delete unused account"
+  expected_feel: "trustworthy"
+  skipped: false
+rejection_reason: "Missing two-step confirmation for account deletion, needs more friction for this high-stakes action"
+learning:
+  inference: "User expects more trust signals for destructive account actions"
+  recommendation: "Add two-step confirmation for account deletion"
+---


### PR DESCRIPTION
## Summary

Implements Sprint 1 (Phase 1) of the Sigil Feedback Loops system, adding interactive diagnostic capabilities to the /craft command.

### Changes

- **Step 6b Diagnostic Mode**: After MODIFY/REJECT signals, prompts user with diagnostic questions
- **Enhanced taste.md Schema**: YAML frontmatter format with DiagnosticContext
- **Taste Parser Specification**: Algorithm and TypeScript interfaces for parsing signals
- **Learning Inference Logic**: 7 automatic inference rules for generating actionable insights
- **Test Signals**: Example signals demonstrating all scenarios

### Key Features

1. **Diagnostic Questions** (triggered on MODIFY/REJECT):
   - User type: power-user, casual, mobile, first-time
   - Goal: free-text description of what user was trying to accomplish
   - Expected feel: instant, snappy, deliberate, trustworthy

2. **Skip Behavior**: Users can skip diagnostics at any time - respects user agency

3. **Learning Inferences**:
   - Effect misclassification detection
   - Mobile user timing preferences
   - Power user frequency patterns
   - Status check detection
   - Trust mismatch warnings
   - Timing and animation change patterns

### Files Changed

| File | Change |
|------|--------|
| `.claude/skills/crafting-physics/SKILL.md` | Added Step 6b, taste parser spec, inference rules |
| `.claude/rules/06-sigil-taste.md` | Enhanced schema, DiagnosticContext docs |
| `grimoires/sigil/taste.md` | Test signals demonstrating format |

## Test plan

- [x] Diagnostic questions appear after MODIFY feedback
- [x] Diagnostic questions appear after REJECT feedback
- [x] ACCEPT signals skip diagnostic (no questions asked)
- [x] Skip option works correctly (skipped: true logged)
- [x] taste.md format matches schema
- [x] Learning inferences are actionable

## Review Notes

- Sprint plan: `grimoires/loa/sprint-feedback-loops.md`
- All S1-01 through S1-05 acceptance criteria met
- Security audit passed (no executable code in this sprint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)