### PR TITLE
feat(hud): v0.2.0 - npm publishing, wagmi integration, inspector

### DIFF
--- a/.github/workflows/publish-hud.yml
+++ b/.github/workflows/publish-hud.yml
@@ -1,0 +1,85 @@
+name: Publish HUD Package
+
+on:
+  push:
+    tags:
+      - 'hud-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build HUD package
+        run: pnpm --filter @thehoneyjar/sigil-hud build
+
+      - name: Verify build output
+        run: |
+          echo "Checking build output..."
+          ls -la packages/hud/dist/
+
+          # Verify main entry exists
+          if [ ! -f "packages/hud/dist/index.js" ]; then
+            echo "ERROR: Main entry (dist/index.js) not found"
+            exit 1
+          fi
+
+          # Verify wagmi subpath exists
+          if [ ! -f "packages/hud/dist/wagmi/index.js" ]; then
+            echo "ERROR: Wagmi entry (dist/wagmi/index.js) not found"
+            exit 1
+          fi
+
+          # Verify type definitions
+          if [ ! -f "packages/hud/dist/index.d.ts" ]; then
+            echo "ERROR: Type definitions (dist/index.d.ts) not found"
+            exit 1
+          fi
+
+          echo "Build verification passed!"
+
+      - name: Publish to npm
+        run: pnpm --filter @thehoneyjar/sigil-hud publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  verify:
+    name: Verify Publication
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for npm propagation
+        run: sleep 30
+
+      - name: Verify package on npm
+        run: |
+          # Extract version from tag
+          VERSION=${GITHUB_REF#refs/tags/hud-v}
+
+          echo "Verifying @thehoneyjar/sigil-hud@$VERSION on npm..."
+          npm view @thehoneyjar/sigil-hud@$VERSION version
+
+          echo "Package successfully published!"

--- a/packages/hud/package.json
+++ b/packages/hud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thehoneyjar/sigil-hud",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Diagnostic HUD for Sigil - composable React components for development",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,6 +10,15 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./wagmi": {
+      "types": "./dist/wagmi/index.d.ts",
+      "import": "./dist/wagmi/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "wagmi": ["./dist/wagmi/index.d.ts"]
     }
   },
   "files": [
@@ -20,7 +29,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
     "zustand": "^4.5.0"
@@ -28,12 +38,20 @@
   "peerDependencies": {
     "react": ">=18.0.0"
   },
+  "peerDependenciesMeta": {
+    "wagmi": {
+      "optional": true
+    },
+    "viem": {
+      "optional": true
+    }
+  },
   "optionalDependencies": {
-    "@thehoneyjar/sigil-anchor": "workspace:*",
-    "@thehoneyjar/sigil-fork": "workspace:*",
-    "@thehoneyjar/sigil-simulation": "workspace:*",
-    "@thehoneyjar/sigil-lens": "workspace:*",
-    "@thehoneyjar/sigil-diagnostics": "workspace:*"
+    "@thehoneyjar/sigil-anchor": "^4.3.0",
+    "@thehoneyjar/sigil-fork": "^0.2.0",
+    "@thehoneyjar/sigil-simulation": "^0.2.0",
+    "@thehoneyjar/sigil-lens": "^0.2.0",
+    "@thehoneyjar/sigil-diagnostics": "^0.2.0"
   },
   "devDependencies": {
     "@thehoneyjar/sigil-anchor": "workspace:*",
@@ -41,10 +59,13 @@
     "@thehoneyjar/sigil-simulation": "workspace:*",
     "@thehoneyjar/sigil-lens": "workspace:*",
     "@thehoneyjar/sigil-diagnostics": "workspace:*",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "react": "^18.0.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "wagmi": "^2.0.0",
+    "viem": "^2.0.0"
   },
   "sideEffects": false,
   "license": "MIT",
@@ -52,5 +73,17 @@
     "type": "git",
     "url": "https://github.com/0xHoneyJar/sigil.git",
     "directory": "packages/hud"
-  }
+  },
+  "homepage": "https://github.com/0xHoneyJar/sigil/tree/main/packages/hud#readme",
+  "bugs": {
+    "url": "https://github.com/0xHoneyJar/sigil/issues"
+  },
+  "keywords": [
+    "sigil",
+    "hud",
+    "diagnostic",
+    "devtools",
+    "react",
+    "web3"
+  ]
 }

--- a/packages/hud/src/components/HudPanel.tsx
+++ b/packages/hud/src/components/HudPanel.tsx
@@ -2,11 +2,13 @@
  * HUD Panel Component
  *
  * Main panel container for the HUD.
+ * Uses inline styles only - no Tailwind classes for consumer compatibility.
  */
 
 import type { ReactNode } from 'react'
 import { useHud } from '../providers/HudProvider'
-import type { HudPanelType } from '../types'
+import { colors, typography, spacing, radii, shadows, zIndex } from '../styles/theme'
+import type { HudPanelType, HudPosition } from '../types'
 
 /**
  * Props for HudPanel
@@ -14,8 +16,6 @@ import type { HudPanelType } from '../types'
 export interface HudPanelProps {
   /** Panel content */
   children?: ReactNode
-  /** Custom class name */
-  className?: string
 }
 
 /**
@@ -28,9 +28,19 @@ interface PanelTab {
 }
 
 /**
+ * Position styles mapping - inline CSS instead of Tailwind classes
+ */
+const positionStyles: Record<HudPosition, React.CSSProperties> = {
+  'bottom-right': { bottom: '16px', right: '16px' },
+  'bottom-left': { bottom: '16px', left: '16px' },
+  'top-right': { top: '16px', right: '16px' },
+  'top-left': { top: '16px', left: '16px' },
+}
+
+/**
  * Main HUD panel component
  */
-export function HudPanel({ children, className = '' }: HudPanelProps) {
+export function HudPanel({ children }: HudPanelProps) {
   const {
     isOpen,
     isMinimized,
@@ -58,27 +68,22 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
 
   const availableTabs = tabs.filter((t) => t.available)
 
-  // Position classes
-  const positionClasses: Record<typeof position, string> = {
-    'bottom-right': 'bottom-4 right-4',
-    'bottom-left': 'bottom-4 left-4',
-    'top-right': 'top-4 right-4',
-    'top-left': 'top-4 left-4',
-  }
-
   return (
     <div
-      className={`fixed ${positionClasses[position]} z-50 ${className}`}
+      data-sigil-hud="panel"
       style={{
+        position: 'fixed',
+        ...positionStyles[position],
+        zIndex: zIndex.fixed,
         width: isMinimized ? '200px' : '400px',
         maxHeight: isMinimized ? '40px' : '600px',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        borderRadius: '8px',
-        border: '1px solid rgba(255, 255, 255, 0.1)',
-        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.5)',
-        fontFamily: 'ui-monospace, monospace',
-        fontSize: '12px',
-        color: '#fff',
+        backgroundColor: colors.background,
+        borderRadius: radii.lg,
+        border: `1px solid ${colors.border}`,
+        boxShadow: shadows.xl,
+        fontFamily: typography.fontFamily,
+        fontSize: typography.base,
+        color: colors.text,
         overflow: 'hidden',
       }}
     >
@@ -89,20 +94,20 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
           alignItems: 'center',
           justifyContent: 'space-between',
           padding: '8px 12px',
-          borderBottom: isMinimized ? 'none' : '1px solid rgba(255, 255, 255, 0.1)',
-          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+          borderBottom: isMinimized ? 'none' : `1px solid ${colors.border}`,
+          backgroundColor: colors.backgroundHover,
         }}
       >
-        <span style={{ fontWeight: 600, color: '#10b981' }}>◆ Sigil HUD</span>
+        <span style={{ fontWeight: typography.semibold, color: colors.primary }}>◆ Sigil HUD</span>
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
             onClick={toggleMinimized}
             style={{
               background: 'none',
               border: 'none',
-              color: '#666',
+              color: colors.textDim,
               cursor: 'pointer',
-              fontSize: '14px',
+              fontSize: typography.lg,
             }}
           >
             {isMinimized ? '◻' : '–'}
@@ -112,9 +117,9 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
             style={{
               background: 'none',
               border: 'none',
-              color: '#666',
+              color: colors.textDim,
               cursor: 'pointer',
-              fontSize: '14px',
+              fontSize: typography.lg,
             }}
           >
             ×
@@ -130,7 +135,7 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
               display: 'flex',
               gap: '2px',
               padding: '4px',
-              backgroundColor: 'rgba(255, 255, 255, 0.02)',
+              backgroundColor: colors.backgroundInput,
             }}
           >
             {availableTabs.map((tab) => (
@@ -139,17 +144,17 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
                 onClick={() => setActivePanel(tab.id)}
                 style={{
                   flex: 1,
-                  padding: '6px 8px',
+                  padding: `${spacing.sm} ${spacing.md}`,
                   background:
                     activePanel === tab.id
-                      ? 'rgba(16, 185, 129, 0.2)'
+                      ? colors.primaryLight
                       : 'transparent',
                   border: 'none',
-                  borderRadius: '4px',
-                  color: activePanel === tab.id ? '#10b981' : '#888',
+                  borderRadius: radii.sm,
+                  color: activePanel === tab.id ? colors.primary : colors.textMuted,
                   cursor: 'pointer',
-                  fontSize: '11px',
-                  fontWeight: 500,
+                  fontSize: typography.sm,
+                  fontWeight: typography.medium,
                 }}
               >
                 {tab.label}
@@ -167,7 +172,7 @@ export function HudPanel({ children, className = '' }: HudPanelProps) {
           >
             {children}
             {!activePanel && (
-              <div style={{ color: '#666', textAlign: 'center', padding: '20px' }}>
+              <div style={{ color: colors.textDim, textAlign: 'center', padding: spacing['2xl'] }}>
                 Select a panel to get started
               </div>
             )}

--- a/packages/hud/src/components/HudTrigger.tsx
+++ b/packages/hud/src/components/HudTrigger.tsx
@@ -2,18 +2,18 @@
  * HUD Trigger Component
  *
  * Floating button to open the HUD.
+ * Uses inline styles only - no Tailwind classes for consumer compatibility.
  */
 
 import type { ReactNode } from 'react'
 import { useHud } from '../providers/HudProvider'
+import { colors, shadows, transitions, zIndex } from '../styles/theme'
 import type { HudPosition } from '../types'
 
 /**
  * Props for HudTrigger
  */
 export interface HudTriggerProps {
-  /** Custom class name */
-  className?: string
   /** Custom children (replaces default icon) */
   children?: ReactNode
   /** Override position (defaults to HUD position) */
@@ -21,10 +21,19 @@ export interface HudTriggerProps {
 }
 
 /**
+ * Position styles mapping - inline CSS instead of Tailwind classes
+ */
+const positionStyles: Record<HudPosition, React.CSSProperties> = {
+  'bottom-right': { bottom: '16px', right: '16px' },
+  'bottom-left': { bottom: '16px', left: '16px' },
+  'top-right': { top: '16px', right: '16px' },
+  'top-left': { top: '16px', left: '16px' },
+}
+
+/**
  * Floating trigger button to open the HUD
  */
 export function HudTrigger({
-  className = '',
   children,
   position: overridePosition,
 }: HudTriggerProps) {
@@ -32,47 +41,42 @@ export function HudTrigger({
 
   const position = overridePosition ?? hudPosition
 
-  // Position classes
-  const positionClasses: Record<typeof position, string> = {
-    'bottom-right': 'bottom-4 right-4',
-    'bottom-left': 'bottom-4 left-4',
-    'top-right': 'top-4 right-4',
-    'top-left': 'top-4 left-4',
-  }
-
   // Don't show trigger when HUD is open
   if (isOpen) return null
 
   return (
     <button
       onClick={toggle}
-      className={`fixed ${positionClasses[position]} z-50 ${className}`}
       style={{
+        position: 'fixed',
+        ...positionStyles[position],
+        zIndex: zIndex.fixed,
         width: '44px',
         height: '44px',
         borderRadius: '50%',
-        backgroundColor: 'rgba(16, 185, 129, 0.9)',
-        border: '2px solid rgba(16, 185, 129, 0.3)',
-        boxShadow: '0 4px 12px rgba(16, 185, 129, 0.3)',
+        backgroundColor: colors.primary,
+        border: `2px solid ${colors.primaryBorder}`,
+        boxShadow: shadows.primary,
         cursor: 'pointer',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        transition: 'transform 0.2s, box-shadow 0.2s',
+        transition: `transform ${transitions.slow}, box-shadow ${transitions.slow}`,
       }}
       onMouseEnter={(e) => {
         e.currentTarget.style.transform = 'scale(1.1)'
-        e.currentTarget.style.boxShadow = '0 6px 16px rgba(16, 185, 129, 0.4)'
+        e.currentTarget.style.boxShadow = shadows.primaryHover
       }}
       onMouseLeave={(e) => {
         e.currentTarget.style.transform = 'scale(1)'
-        e.currentTarget.style.boxShadow = '0 4px 12px rgba(16, 185, 129, 0.3)'
+        e.currentTarget.style.boxShadow = shadows.primary
       }}
       aria-label="Open Sigil HUD"
-      title="Sigil HUD (⌘⇧D)"
+      title="Sigil HUD (Ctrl+Shift+D)"
+      data-sigil-hud="trigger"
     >
       {children ?? (
-        <span style={{ color: '#fff', fontSize: '18px', fontWeight: 600 }}>
+        <span style={{ color: colors.text, fontSize: '18px', fontWeight: 600 }}>
           ◆
         </span>
       )}

--- a/packages/hud/src/components/JsonPreview.tsx
+++ b/packages/hud/src/components/JsonPreview.tsx
@@ -1,0 +1,247 @@
+/**
+ * JSON Preview Component
+ *
+ * Displays JSON data with a sticky copy header.
+ * Designed to fix #46 - JSON preview requires horizontal scroll,
+ * copy button placement forces scrolling.
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import { colors, typography, spacing, radii } from '../styles/theme'
+
+/**
+ * Props for JsonPreview component
+ */
+export interface JsonPreviewProps {
+  /** Data to display as JSON */
+  data: unknown
+  /** Optional title for the preview */
+  title?: string
+  /** Maximum height before scrolling (default: 300) */
+  maxHeight?: number
+  /** Show copy button (default: true) */
+  copyable?: boolean
+}
+
+/**
+ * Styles for JsonPreview component
+ */
+const styles = {
+  container: {
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
+    borderRadius: radii.lg,
+    border: `1px solid ${colors.borderSubtle}`,
+    overflow: 'hidden',
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+  } as const,
+
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: `${spacing.sm} ${spacing.lg}`,
+    backgroundColor: colors.backgroundHover,
+    borderBottom: `1px solid ${colors.borderSubtle}`,
+    position: 'sticky' as const,
+    top: 0,
+    zIndex: 1,
+  } as const,
+
+  title: {
+    color: colors.textMuted,
+    fontWeight: typography.medium,
+    fontSize: typography.xs,
+    textTransform: 'uppercase' as const,
+    letterSpacing: typography.letterSpacingWide,
+  } as const,
+
+  copyButton: {
+    backgroundColor: colors.primaryLight,
+    color: colors.primary,
+    border: `1px solid ${colors.primaryBorder}`,
+    borderRadius: radii.sm,
+    padding: `${spacing.xs} ${spacing.md}`,
+    cursor: 'pointer',
+    fontSize: typography.xs,
+    fontWeight: typography.medium,
+    fontFamily: typography.fontFamily,
+    transition: 'opacity 0.2s',
+  } as const,
+
+  copyButtonHover: {
+    opacity: 0.8,
+  } as const,
+
+  content: {
+    padding: spacing.lg,
+    overflowX: 'auto' as const,
+    overflowY: 'auto' as const,
+  } as const,
+
+  pre: {
+    margin: 0,
+    whiteSpace: 'pre-wrap' as const,
+    wordBreak: 'break-word' as const,
+    color: colors.text,
+    lineHeight: typography.lineHeightRelaxed,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+  } as const,
+
+  // Syntax highlighting colors
+  key: {
+    color: colors.info,
+  } as const,
+
+  string: {
+    color: colors.success,
+  } as const,
+
+  number: {
+    color: colors.warning,
+  } as const,
+
+  boolean: {
+    color: colors.primary,
+  } as const,
+
+  null: {
+    color: colors.textDim,
+  } as const,
+}
+
+/**
+ * Simple JSON syntax highlighter
+ */
+function highlightJson(json: string): React.ReactNode[] {
+  const tokens: React.ReactNode[] = []
+  let i = 0
+
+  // Regex patterns for JSON tokens
+  const patterns = [
+    { regex: /"([^"\\]|\\.)*"(?=\s*:)/g, style: styles.key, name: 'key' }, // Keys
+    { regex: /"([^"\\]|\\.)*"/g, style: styles.string, name: 'string' }, // Strings
+    { regex: /-?\d+\.?\d*([eE][+-]?\d+)?/g, style: styles.number, name: 'number' }, // Numbers
+    { regex: /\b(true|false)\b/g, style: styles.boolean, name: 'boolean' }, // Booleans
+    { regex: /\bnull\b/g, style: styles.null, name: 'null' }, // Null
+  ]
+
+  while (i < json.length) {
+    let matched = false
+
+    for (const { regex, style, name } of patterns) {
+      regex.lastIndex = i
+      const match = regex.exec(json)
+
+      if (match && match.index === i) {
+        // Add any preceding plain text
+        if (tokens.length === 0 || typeof tokens[tokens.length - 1] !== 'string') {
+          // This is fine
+        }
+
+        tokens.push(
+          <span key={`${name}-${i}`} style={style}>
+            {match[0]}
+          </span>
+        )
+        i += match[0].length
+        matched = true
+        break
+      }
+    }
+
+    if (!matched) {
+      // Add plain character
+      const lastToken = tokens[tokens.length - 1]
+      if (typeof lastToken === 'string') {
+        tokens[tokens.length - 1] = lastToken + json[i]
+      } else {
+        tokens.push(json[i])
+      }
+      i++
+    }
+  }
+
+  return tokens
+}
+
+/**
+ * JSON Preview component with sticky copy header
+ *
+ * Addresses GitHub issue #46:
+ * - Uses `white-space: pre-wrap` to avoid horizontal scroll
+ * - Copy button is in a sticky header, always visible
+ * - Syntax highlighting for better readability
+ *
+ * @example
+ * ```tsx
+ * <JsonPreview
+ *   title="Response"
+ *   data={{ user: { name: "Alice", balance: 1000 } }}
+ *   maxHeight={400}
+ * />
+ * ```
+ */
+export function JsonPreview({
+  data,
+  title,
+  maxHeight = 300,
+  copyable = true,
+}: JsonPreviewProps) {
+  const [copied, setCopied] = useState(false)
+  const [isHovering, setIsHovering] = useState(false)
+
+  const json = useMemo(() => JSON.stringify(data, null, 2), [data])
+
+  const highlighted = useMemo(() => highlightJson(json), [json])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(json)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      // Fallback for browsers without clipboard API
+      const textarea = document.createElement('textarea')
+      textarea.value = json
+      textarea.style.position = 'fixed'
+      textarea.style.opacity = '0'
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }, [json])
+
+  const showHeader = title || copyable
+
+  return (
+    <div style={styles.container} data-sigil-hud="json-preview">
+      {showHeader && (
+        <div style={styles.header}>
+          {title && <span style={styles.title}>{title}</span>}
+          {!title && <span />}
+          {copyable && (
+            <button
+              onClick={handleCopy}
+              onMouseEnter={() => setIsHovering(true)}
+              onMouseLeave={() => setIsHovering(false)}
+              style={{
+                ...styles.copyButton,
+                ...(isHovering ? styles.copyButtonHover : {}),
+              }}
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          )}
+        </div>
+      )}
+      <div style={{ ...styles.content, maxHeight }}>
+        <pre style={styles.pre}>{highlighted}</pre>
+      </div>
+    </div>
+  )
+}

--- a/packages/hud/src/index.ts
+++ b/packages/hud/src/index.ts
@@ -79,6 +79,31 @@ export type { ObservationCaptureModalProps } from './components/ObservationCaptu
 export { FeedbackPrompt } from './components/FeedbackPrompt'
 export type { FeedbackPromptProps } from './components/FeedbackPrompt'
 
+export { JsonPreview } from './components/JsonPreview'
+export type { JsonPreviewProps } from './components/JsonPreview'
+
+// Inspector
+export {
+  useElementInspector,
+  useAnnotationSession,
+  ElementInspector,
+  AnnotationMarker,
+  AnnotationMarkerList,
+  CATEGORY_INFO,
+} from './inspector'
+export type {
+  InspectedElement,
+  UseElementInspectorOptions,
+  UseElementInspectorReturn,
+  Annotation,
+  AnnotationCategory,
+  UseAnnotationSessionOptions,
+  UseAnnotationSessionReturn,
+  ElementInspectorProps,
+  AnnotationMarkerProps,
+  AnnotationMarkerListProps,
+} from './inspector'
+
 // Hooks
 export { useKeyboardShortcuts, getShortcutHelp } from './hooks/useKeyboardShortcuts'
 export type { UseKeyboardShortcutsProps } from './hooks/useKeyboardShortcuts'

--- a/packages/hud/src/inspector/AnnotationMarker.tsx
+++ b/packages/hud/src/inspector/AnnotationMarker.tsx
@@ -1,0 +1,354 @@
+/**
+ * Annotation Marker Component
+ *
+ * Visual markers displayed on annotated elements.
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { colors, typography, spacing, radii, shadows, zIndex } from '../styles/theme'
+import type { Annotation, AnnotationCategory } from './useAnnotationSession'
+
+/**
+ * Props for AnnotationMarker component
+ */
+export interface AnnotationMarkerProps {
+  /** The annotation to display */
+  annotation: Annotation
+  /** Index number for display */
+  index: number
+  /** Whether the marker is highlighted */
+  isHighlighted?: boolean
+  /** Callback when marker is clicked */
+  onClick?: (annotation: Annotation) => void
+  /** Callback when annotation is deleted */
+  onDelete?: (id: string) => void
+}
+
+/**
+ * Category colors
+ */
+const CATEGORY_COLORS: Record<AnnotationCategory, string> = {
+  physics: colors.warning,
+  layout: colors.info,
+  accessibility: '#a855f7', // purple
+  performance: colors.success,
+  ux: '#ec4899', // pink
+  bug: colors.error,
+  suggestion: colors.primary,
+  other: colors.textMuted,
+}
+
+/**
+ * Category emojis
+ */
+const CATEGORY_EMOJIS: Record<AnnotationCategory, string> = {
+  physics: '⚡',
+  layout: '📐',
+  accessibility: '♿',
+  performance: '🚀',
+  ux: '👤',
+  bug: '🐛',
+  suggestion: '💡',
+  other: '📝',
+}
+
+/**
+ * Styles for AnnotationMarker
+ */
+const createStyles = (color: string) => ({
+  marker: {
+    position: 'fixed' as const,
+    zIndex: zIndex.tooltip,
+    pointerEvents: 'auto' as const,
+    cursor: 'pointer',
+  },
+
+  badge: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    borderRadius: '50%',
+    backgroundColor: color,
+    color: '#000',
+    fontSize: typography.xs,
+    fontWeight: typography.bold,
+    fontFamily: typography.fontFamily,
+    boxShadow: shadows.md,
+    transition: 'transform 0.15s ease-out',
+    border: '2px solid #fff',
+  },
+
+  badgeHovered: {
+    transform: 'scale(1.2)',
+  },
+
+  tooltip: {
+    position: 'absolute' as const,
+    top: '100%',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    marginTop: spacing.sm,
+    padding: spacing.md,
+    backgroundColor: colors.background,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.lg,
+    boxShadow: shadows.lg,
+    minWidth: '200px',
+    maxWidth: '280px',
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+    color: colors.text,
+    zIndex: 1,
+  },
+
+  tooltipHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+    paddingBottom: spacing.sm,
+    borderBottom: `1px solid ${colors.borderSubtle}`,
+  },
+
+  tooltipCategory: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: `2px ${spacing.sm}`,
+    backgroundColor: `${color}20`,
+    color: color,
+    border: `1px solid ${color}40`,
+    borderRadius: radii.sm,
+    fontSize: typography.xs,
+    fontWeight: typography.medium,
+  },
+
+  tooltipElement: {
+    fontSize: typography.xs,
+    color: colors.textMuted,
+  },
+
+  tooltipNote: {
+    lineHeight: typography.lineHeightNormal,
+    wordBreak: 'break-word' as const,
+  },
+
+  tooltipFooter: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: spacing.sm,
+    paddingTop: spacing.sm,
+    borderTop: `1px solid ${colors.borderSubtle}`,
+  },
+
+  tooltipTime: {
+    fontSize: typography.xs,
+    color: colors.textDim,
+  },
+
+  deleteButton: {
+    backgroundColor: 'transparent',
+    border: `1px solid ${colors.errorBorder}`,
+    color: colors.error,
+    padding: `2px ${spacing.sm}`,
+    borderRadius: radii.sm,
+    fontSize: typography.xs,
+    cursor: 'pointer',
+    fontFamily: typography.fontFamily,
+    transition: 'background-color 0.15s',
+  },
+
+  outline: {
+    position: 'fixed' as const,
+    pointerEvents: 'none' as const,
+    border: `2px dashed ${color}`,
+    borderRadius: radii.sm,
+    zIndex: zIndex.tooltip - 1,
+  },
+})
+
+/**
+ * Annotation Marker component
+ */
+export function AnnotationMarker({
+  annotation,
+  index,
+  isHighlighted = false,
+  onClick,
+  onDelete,
+}: AnnotationMarkerProps) {
+  const [isHovered, setIsHovered] = useState(false)
+  const [rect, setRect] = useState<DOMRect | null>(null)
+
+  const color = CATEGORY_COLORS[annotation.category]
+  const emoji = CATEGORY_EMOJIS[annotation.category]
+  const styles = useMemo(() => createStyles(color), [color])
+
+  // Update rect when annotation changes or on resize
+  useEffect(() => {
+    const updateRect = () => {
+      try {
+        const element = document.querySelector(annotation.element.selector)
+        if (element) {
+          setRect(element.getBoundingClientRect())
+        } else {
+          setRect(null)
+        }
+      } catch {
+        setRect(null)
+      }
+    }
+
+    updateRect()
+
+    // Update on resize and scroll
+    window.addEventListener('resize', updateRect)
+    window.addEventListener('scroll', updateRect, true)
+
+    return () => {
+      window.removeEventListener('resize', updateRect)
+      window.removeEventListener('scroll', updateRect, true)
+    }
+  }, [annotation.element.selector])
+
+  const handleClick = useCallback(() => {
+    onClick?.(annotation)
+  }, [annotation, onClick])
+
+  const handleDelete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onDelete?.(annotation.id)
+    },
+    [annotation.id, onDelete]
+  )
+
+  const formatTime = useCallback((timestamp: number) => {
+    return new Date(timestamp).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }, [])
+
+  // Don't render if element not found
+  if (!rect) {
+    return null
+  }
+
+  const showTooltip = isHovered || isHighlighted
+
+  return (
+    <>
+      {/* Element outline when hovered */}
+      {showTooltip && (
+        <div
+          style={{
+            ...styles.outline,
+            left: rect.left - 2,
+            top: rect.top - 2,
+            width: rect.width + 4,
+            height: rect.height + 4,
+          }}
+          data-sigil-hud="annotation-outline"
+        />
+      )}
+
+      {/* Marker badge */}
+      <div
+        style={{
+          ...styles.marker,
+          left: rect.right - 12,
+          top: rect.top - 12,
+        }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={handleClick}
+        data-sigil-hud="annotation-marker"
+      >
+        <div
+          style={{
+            ...styles.badge,
+            ...(showTooltip ? styles.badgeHovered : {}),
+          }}
+        >
+          {index + 1}
+        </div>
+
+        {/* Tooltip */}
+        {showTooltip && (
+          <div style={styles.tooltip}>
+            <div style={styles.tooltipHeader}>
+              <span style={styles.tooltipCategory}>
+                <span>{emoji}</span>
+                <span>{annotation.category}</span>
+              </span>
+              <span style={styles.tooltipElement}>
+                {annotation.element.componentName ?? annotation.element.tagName}
+              </span>
+            </div>
+
+            <div style={styles.tooltipNote}>{annotation.note}</div>
+
+            <div style={styles.tooltipFooter}>
+              <span style={styles.tooltipTime}>{formatTime(annotation.timestamp)}</span>
+              {onDelete && (
+                <button
+                  style={styles.deleteButton}
+                  onClick={handleDelete}
+                  onMouseOver={(e) =>
+                    (e.currentTarget.style.backgroundColor = colors.errorLight)
+                  }
+                  onMouseOut={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+/**
+ * Props for AnnotationMarkerList component
+ */
+export interface AnnotationMarkerListProps {
+  /** All annotations to display */
+  annotations: Annotation[]
+  /** ID of highlighted annotation */
+  highlightedId?: string | null
+  /** Callback when a marker is clicked */
+  onMarkerClick?: (annotation: Annotation) => void
+  /** Callback when an annotation is deleted */
+  onDelete?: (id: string) => void
+}
+
+/**
+ * Component to render all annotation markers
+ */
+export function AnnotationMarkerList({
+  annotations,
+  highlightedId,
+  onMarkerClick,
+  onDelete,
+}: AnnotationMarkerListProps) {
+  return (
+    <>
+      {annotations.map((annotation, index) => (
+        <AnnotationMarker
+          key={annotation.id}
+          annotation={annotation}
+          index={index}
+          isHighlighted={annotation.id === highlightedId}
+          onClick={onMarkerClick}
+          onDelete={onDelete}
+        />
+      ))}
+    </>
+  )
+}

--- a/packages/hud/src/inspector/ElementInspector.tsx
+++ b/packages/hud/src/inspector/ElementInspector.tsx
@@ -1,0 +1,504 @@
+/**
+ * Element Inspector Component
+ *
+ * Visual overlay for element inspection with hover highlighting
+ * and element info display.
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import { colors, typography, spacing, radii, shadows, zIndex } from '../styles/theme'
+import type { InspectedElement } from './useElementInspector'
+import type { AnnotationCategory } from './useAnnotationSession'
+
+/**
+ * Props for ElementInspector component
+ */
+export interface ElementInspectorProps {
+  /** Currently hovered element */
+  hoveredElement: InspectedElement | null
+  /** Currently selected element */
+  selectedElement: InspectedElement | null
+  /** Whether inspector is active */
+  isInspecting: boolean
+  /** Callback to add annotation */
+  onAnnotate?: (element: InspectedElement, note: string, category: AnnotationCategory) => void
+  /** Callback when selection is cleared */
+  onClearSelection?: () => void
+  /** Callback to stop inspecting */
+  onStopInspecting?: () => void
+}
+
+/**
+ * Styles for ElementInspector
+ */
+const styles = {
+  // Highlight overlay for hovered elements
+  highlightOverlay: {
+    position: 'fixed' as const,
+    pointerEvents: 'none' as const,
+    zIndex: zIndex.tooltip,
+    border: `2px solid ${colors.primary}`,
+    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+    borderRadius: radii.sm,
+    transition: 'all 0.1s ease-out',
+  },
+
+  // Label showing component/element name
+  highlightLabel: {
+    position: 'absolute' as const,
+    bottom: '100%',
+    left: '0',
+    marginBottom: '4px',
+    padding: `2px ${spacing.sm}`,
+    backgroundColor: colors.primary,
+    color: '#000',
+    fontSize: typography.xs,
+    fontFamily: typography.fontFamily,
+    fontWeight: typography.semibold,
+    borderRadius: radii.sm,
+    whiteSpace: 'nowrap' as const,
+  },
+
+  // Selection overlay (darker border)
+  selectionOverlay: {
+    position: 'fixed' as const,
+    pointerEvents: 'none' as const,
+    zIndex: zIndex.tooltip + 1,
+    border: `3px solid ${colors.info}`,
+    backgroundColor: 'rgba(59, 130, 246, 0.1)',
+    borderRadius: radii.sm,
+  },
+
+  // Info panel for selected element
+  infoPanel: {
+    position: 'fixed' as const,
+    zIndex: zIndex.modal,
+    backgroundColor: colors.background,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.lg,
+    boxShadow: shadows.xl,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+    color: colors.text,
+    minWidth: '300px',
+    maxWidth: '400px',
+    overflow: 'hidden',
+  },
+
+  infoPanelHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.md,
+    borderBottom: `1px solid ${colors.borderSubtle}`,
+    backgroundColor: colors.backgroundHover,
+  },
+
+  infoPanelTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.sm,
+    fontWeight: typography.semibold,
+    color: colors.text,
+  },
+
+  componentBadge: {
+    padding: `2px ${spacing.sm}`,
+    backgroundColor: colors.infoLight,
+    color: colors.info,
+    border: `1px solid ${colors.infoBorder}`,
+    borderRadius: radii.sm,
+    fontSize: typography.xs,
+  },
+
+  closeButton: {
+    backgroundColor: 'transparent',
+    border: 'none',
+    color: colors.textMuted,
+    cursor: 'pointer',
+    padding: spacing.xs,
+    fontSize: typography.md,
+    lineHeight: 1,
+    borderRadius: radii.sm,
+    transition: 'color 0.15s',
+  },
+
+  infoPanelContent: {
+    padding: spacing.md,
+  },
+
+  infoRow: {
+    display: 'flex',
+    marginBottom: spacing.sm,
+  },
+
+  infoLabel: {
+    width: '80px',
+    flexShrink: 0,
+    color: colors.textMuted,
+    fontSize: typography.xs,
+    textTransform: 'uppercase' as const,
+    letterSpacing: typography.letterSpacingWide,
+  },
+
+  infoValue: {
+    flex: 1,
+    color: colors.text,
+    fontFamily: typography.fontFamily,
+    wordBreak: 'break-all' as const,
+  },
+
+  selectorValue: {
+    padding: `2px ${spacing.xs}`,
+    backgroundColor: colors.backgroundInput,
+    borderRadius: radii.sm,
+    fontSize: typography.xs,
+    wordBreak: 'break-all' as const,
+  },
+
+  annotateSection: {
+    padding: spacing.md,
+    borderTop: `1px solid ${colors.borderSubtle}`,
+  },
+
+  annotateTextarea: {
+    width: '100%',
+    padding: spacing.sm,
+    backgroundColor: colors.backgroundInput,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.md,
+    color: colors.text,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+    resize: 'vertical' as const,
+    minHeight: '60px',
+    marginBottom: spacing.sm,
+    outline: 'none',
+  },
+
+  categorySelect: {
+    width: '100%',
+    padding: spacing.sm,
+    backgroundColor: colors.backgroundInput,
+    border: `1px solid ${colors.border}`,
+    borderRadius: radii.md,
+    color: colors.text,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+    marginBottom: spacing.sm,
+    outline: 'none',
+    cursor: 'pointer',
+  },
+
+  buttonRow: {
+    display: 'flex',
+    gap: spacing.sm,
+    justifyContent: 'flex-end',
+  },
+
+  button: {
+    padding: `${spacing.sm} ${spacing.md}`,
+    borderRadius: radii.md,
+    fontSize: typography.sm,
+    fontWeight: typography.medium,
+    fontFamily: typography.fontFamily,
+    cursor: 'pointer',
+    transition: 'opacity 0.15s',
+    border: '1px solid',
+  },
+
+  primaryButton: {
+    backgroundColor: colors.primaryLight,
+    borderColor: colors.primaryBorder,
+    color: colors.primary,
+  },
+
+  secondaryButton: {
+    backgroundColor: 'transparent',
+    borderColor: colors.border,
+    color: colors.textMuted,
+  },
+
+  // Inspector mode indicator
+  modeIndicator: {
+    position: 'fixed' as const,
+    top: spacing.md,
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: zIndex.modal,
+    padding: `${spacing.sm} ${spacing.lg}`,
+    backgroundColor: colors.background,
+    border: `1px solid ${colors.primaryBorder}`,
+    borderRadius: radii.full,
+    fontFamily: typography.fontFamily,
+    fontSize: typography.sm,
+    color: colors.text,
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacing.sm,
+    boxShadow: shadows.md,
+  },
+
+  modeIndicatorDot: {
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    backgroundColor: colors.primary,
+    animation: 'pulse 2s infinite',
+  },
+
+  escHint: {
+    color: colors.textMuted,
+    fontSize: typography.xs,
+  },
+}
+
+// CSS for pulse animation (injected via style tag)
+const pulseAnimation = `
+@keyframes sigil-inspector-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+`
+
+/**
+ * Category options for annotation
+ */
+const CATEGORY_OPTIONS: { value: AnnotationCategory; label: string }[] = [
+  { value: 'physics', label: '⚡ Physics' },
+  { value: 'layout', label: '📐 Layout' },
+  { value: 'accessibility', label: '♿ Accessibility' },
+  { value: 'performance', label: '🚀 Performance' },
+  { value: 'ux', label: '👤 UX' },
+  { value: 'bug', label: '🐛 Bug' },
+  { value: 'suggestion', label: '💡 Suggestion' },
+  { value: 'other', label: '📝 Other' },
+]
+
+/**
+ * Element Inspector component
+ */
+export function ElementInspector({
+  hoveredElement,
+  selectedElement,
+  isInspecting,
+  onAnnotate,
+  onClearSelection,
+  onStopInspecting,
+}: ElementInspectorProps) {
+  const [note, setNote] = useState('')
+  const [category, setCategory] = useState<AnnotationCategory>('ux')
+
+  // Calculate info panel position
+  const infoPanelPosition = useMemo(() => {
+    if (!selectedElement) return null
+
+    const rect = selectedElement.rect
+    const panelWidth = 350
+    const panelHeight = 300 // Approximate
+    const margin = 16
+
+    let left = rect.right + margin
+    let top = rect.top
+
+    // Check if panel would overflow right
+    if (left + panelWidth > window.innerWidth - margin) {
+      left = rect.left - panelWidth - margin
+    }
+
+    // Check if panel would overflow left
+    if (left < margin) {
+      left = margin
+    }
+
+    // Check if panel would overflow bottom
+    if (top + panelHeight > window.innerHeight - margin) {
+      top = window.innerHeight - panelHeight - margin
+    }
+
+    // Check if panel would overflow top
+    if (top < margin) {
+      top = margin
+    }
+
+    return { left, top }
+  }, [selectedElement])
+
+  // Handle annotation submit
+  const handleAnnotate = useCallback(() => {
+    if (!selectedElement || !note.trim()) return
+    onAnnotate?.(selectedElement, note.trim(), category)
+    setNote('')
+    onClearSelection?.()
+  }, [selectedElement, note, category, onAnnotate, onClearSelection])
+
+  // Handle close
+  const handleClose = useCallback(() => {
+    setNote('')
+    onClearSelection?.()
+  }, [onClearSelection])
+
+  if (!isInspecting && !selectedElement) {
+    return null
+  }
+
+  return (
+    <>
+      {/* Inject pulse animation */}
+      <style>{pulseAnimation}</style>
+
+      {/* Mode indicator when inspecting */}
+      {isInspecting && (
+        <div style={styles.modeIndicator} data-sigil-hud="inspector-indicator">
+          <div
+            style={{
+              ...styles.modeIndicatorDot,
+              animation: 'sigil-inspector-pulse 2s infinite',
+            }}
+          />
+          <span>Inspector Mode</span>
+          <span style={styles.escHint}>Press ESC to exit</span>
+        </div>
+      )}
+
+      {/* Hover highlight */}
+      {hoveredElement && isInspecting && (
+        <div
+          style={{
+            ...styles.highlightOverlay,
+            left: hoveredElement.rect.left - 2,
+            top: hoveredElement.rect.top - 2,
+            width: hoveredElement.rect.width + 4,
+            height: hoveredElement.rect.height + 4,
+          }}
+          data-sigil-hud="inspector-highlight"
+        >
+          <div style={styles.highlightLabel}>
+            {hoveredElement.componentName ?? hoveredElement.tagName}
+          </div>
+        </div>
+      )}
+
+      {/* Selection highlight */}
+      {selectedElement && (
+        <div
+          style={{
+            ...styles.selectionOverlay,
+            left: selectedElement.rect.left - 3,
+            top: selectedElement.rect.top - 3,
+            width: selectedElement.rect.width + 6,
+            height: selectedElement.rect.height + 6,
+          }}
+          data-sigil-hud="inspector-selection"
+        />
+      )}
+
+      {/* Info panel for selected element */}
+      {selectedElement && infoPanelPosition && (
+        <div
+          style={{
+            ...styles.infoPanel,
+            left: infoPanelPosition.left,
+            top: infoPanelPosition.top,
+          }}
+          data-sigil-hud="inspector-panel"
+        >
+          {/* Header */}
+          <div style={styles.infoPanelHeader}>
+            <div style={styles.infoPanelTitle}>
+              <span>{selectedElement.tagName}</span>
+              {selectedElement.componentName && (
+                <span style={styles.componentBadge}>{selectedElement.componentName}</span>
+              )}
+            </div>
+            <button
+              style={styles.closeButton}
+              onClick={handleClose}
+              onMouseOver={(e) => (e.currentTarget.style.color = colors.text)}
+              onMouseOut={(e) => (e.currentTarget.style.color = colors.textMuted)}
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Content */}
+          <div style={styles.infoPanelContent}>
+            <div style={styles.infoRow}>
+              <span style={styles.infoLabel}>Selector</span>
+              <code style={{ ...styles.infoValue, ...styles.selectorValue }}>
+                {selectedElement.selector}
+              </code>
+            </div>
+
+            {selectedElement.id && (
+              <div style={styles.infoRow}>
+                <span style={styles.infoLabel}>ID</span>
+                <span style={styles.infoValue}>{selectedElement.id}</span>
+              </div>
+            )}
+
+            {selectedElement.classList.length > 0 && (
+              <div style={styles.infoRow}>
+                <span style={styles.infoLabel}>Classes</span>
+                <span style={styles.infoValue}>
+                  {selectedElement.classList.slice(0, 5).join(', ')}
+                  {selectedElement.classList.length > 5 &&
+                    ` +${selectedElement.classList.length - 5} more`}
+                </span>
+              </div>
+            )}
+
+            {selectedElement.sigilAttribute && (
+              <div style={styles.infoRow}>
+                <span style={styles.infoLabel}>Sigil</span>
+                <span style={styles.infoValue}>{selectedElement.sigilAttribute}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Annotation section */}
+          {onAnnotate && (
+            <div style={styles.annotateSection}>
+              <textarea
+                style={styles.annotateTextarea}
+                placeholder="Add a note about this element..."
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                onFocus={(e) => (e.currentTarget.style.borderColor = colors.primary)}
+                onBlur={(e) => (e.currentTarget.style.borderColor = colors.border)}
+              />
+
+              <select
+                style={styles.categorySelect}
+                value={category}
+                onChange={(e) => setCategory(e.target.value as AnnotationCategory)}
+              >
+                {CATEGORY_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+
+              <div style={styles.buttonRow}>
+                <button
+                  style={{ ...styles.button, ...styles.secondaryButton }}
+                  onClick={handleClose}
+                >
+                  Cancel
+                </button>
+                <button
+                  style={{ ...styles.button, ...styles.primaryButton }}
+                  onClick={handleAnnotate}
+                  disabled={!note.trim()}
+                >
+                  Add Annotation
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/hud/src/inspector/index.ts
+++ b/packages/hud/src/inspector/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Element Inspector Module
+ *
+ * Provides element inspection and annotation capabilities for design review.
+ */
+
+// Hooks
+export { useElementInspector } from './useElementInspector'
+export type {
+  InspectedElement,
+  UseElementInspectorOptions,
+  UseElementInspectorReturn,
+} from './useElementInspector'
+
+export { useAnnotationSession, CATEGORY_INFO } from './useAnnotationSession'
+export type {
+  Annotation,
+  AnnotationCategory,
+  UseAnnotationSessionOptions,
+  UseAnnotationSessionReturn,
+} from './useAnnotationSession'
+
+// Components
+export { ElementInspector } from './ElementInspector'
+export type { ElementInspectorProps } from './ElementInspector'
+
+export { AnnotationMarker, AnnotationMarkerList } from './AnnotationMarker'
+export type { AnnotationMarkerProps, AnnotationMarkerListProps } from './AnnotationMarker'

--- a/packages/hud/src/inspector/useAnnotationSession.ts
+++ b/packages/hud/src/inspector/useAnnotationSession.ts
@@ -1,0 +1,273 @@
+/**
+ * Annotation Session Hook
+ *
+ * Manages a collection of annotated elements and exports them to markdown.
+ * Designed for design review workflows.
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import type { InspectedElement } from './useElementInspector'
+
+/**
+ * An annotation on an element
+ */
+export interface Annotation {
+  /** Unique identifier */
+  id: string
+  /** The inspected element info */
+  element: InspectedElement
+  /** User's note about this element */
+  note: string
+  /** Category of the annotation */
+  category: AnnotationCategory
+  /** Timestamp when annotation was created */
+  timestamp: number
+  /** Optional screenshot data URL */
+  screenshot?: string
+}
+
+/**
+ * Categories for annotations
+ */
+export type AnnotationCategory =
+  | 'physics'
+  | 'layout'
+  | 'accessibility'
+  | 'performance'
+  | 'ux'
+  | 'bug'
+  | 'suggestion'
+  | 'other'
+
+/**
+ * Options for the annotation session hook
+ */
+export interface UseAnnotationSessionOptions {
+  /** Session name/title */
+  sessionName?: string
+  /** Callback when session is exported */
+  onExport?: (markdown: string, annotations: Annotation[]) => void
+}
+
+/**
+ * Return type for useAnnotationSession
+ */
+export interface UseAnnotationSessionReturn {
+  /** All annotations in the session */
+  annotations: Annotation[]
+  /** Add a new annotation */
+  addAnnotation: (
+    element: InspectedElement,
+    note: string,
+    category: AnnotationCategory,
+    screenshot?: string
+  ) => Annotation
+  /** Remove an annotation */
+  removeAnnotation: (id: string) => void
+  /** Update an annotation */
+  updateAnnotation: (id: string, updates: Partial<Pick<Annotation, 'note' | 'category'>>) => void
+  /** Clear all annotations */
+  clearAnnotations: () => void
+  /** Export annotations to markdown */
+  exportToMarkdown: () => string
+  /** Get annotations by category */
+  getByCategory: (category: AnnotationCategory) => Annotation[]
+  /** Session statistics */
+  stats: {
+    total: number
+    byCategory: Record<AnnotationCategory, number>
+  }
+}
+
+/**
+ * Category display names and icons
+ */
+const CATEGORY_INFO: Record<AnnotationCategory, { label: string; emoji: string }> = {
+  physics: { label: 'Physics', emoji: '⚡' },
+  layout: { label: 'Layout', emoji: '📐' },
+  accessibility: { label: 'Accessibility', emoji: '♿' },
+  performance: { label: 'Performance', emoji: '🚀' },
+  ux: { label: 'UX', emoji: '👤' },
+  bug: { label: 'Bug', emoji: '🐛' },
+  suggestion: { label: 'Suggestion', emoji: '💡' },
+  other: { label: 'Other', emoji: '📝' },
+}
+
+/**
+ * Generate a unique ID
+ */
+function generateId(): string {
+  return `ann_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+}
+
+/**
+ * Hook for managing annotation sessions
+ */
+export function useAnnotationSession(
+  options: UseAnnotationSessionOptions = {}
+): UseAnnotationSessionReturn {
+  const { sessionName = 'Design Review', onExport } = options
+
+  const [annotations, setAnnotations] = useState<Annotation[]>([])
+
+  // Add annotation
+  const addAnnotation = useCallback(
+    (
+      element: InspectedElement,
+      note: string,
+      category: AnnotationCategory,
+      screenshot?: string
+    ): Annotation => {
+      const annotation: Annotation = {
+        id: generateId(),
+        element,
+        note,
+        category,
+        timestamp: Date.now(),
+        screenshot,
+      }
+
+      setAnnotations((prev) => [...prev, annotation])
+      return annotation
+    },
+    []
+  )
+
+  // Remove annotation
+  const removeAnnotation = useCallback((id: string) => {
+    setAnnotations((prev) => prev.filter((a) => a.id !== id))
+  }, [])
+
+  // Update annotation
+  const updateAnnotation = useCallback(
+    (id: string, updates: Partial<Pick<Annotation, 'note' | 'category'>>) => {
+      setAnnotations((prev) =>
+        prev.map((a) => (a.id === id ? { ...a, ...updates } : a))
+      )
+    },
+    []
+  )
+
+  // Clear all annotations
+  const clearAnnotations = useCallback(() => {
+    setAnnotations([])
+  }, [])
+
+  // Get annotations by category
+  const getByCategory = useCallback(
+    (category: AnnotationCategory) => {
+      return annotations.filter((a) => a.category === category)
+    },
+    [annotations]
+  )
+
+  // Export to markdown
+  const exportToMarkdown = useCallback((): string => {
+    const now = new Date()
+    const dateStr = now.toISOString().split('T')[0]
+    const timeStr = now.toTimeString().split(' ')[0]
+
+    const lines: string[] = [
+      `# ${sessionName}`,
+      '',
+      `**Date:** ${dateStr}`,
+      `**Time:** ${timeStr}`,
+      `**Total Annotations:** ${annotations.length}`,
+      '',
+      '---',
+      '',
+    ]
+
+    // Group by category
+    const byCategory = new Map<AnnotationCategory, Annotation[]>()
+    for (const annotation of annotations) {
+      const list = byCategory.get(annotation.category) ?? []
+      list.push(annotation)
+      byCategory.set(annotation.category, list)
+    }
+
+    // Generate sections for each category
+    for (const [category, categoryAnnotations] of byCategory) {
+      const info = CATEGORY_INFO[category]
+      lines.push(`## ${info.emoji} ${info.label}`)
+      lines.push('')
+
+      for (const annotation of categoryAnnotations) {
+        const time = new Date(annotation.timestamp).toLocaleTimeString()
+        lines.push(`### ${annotation.element.componentName ?? annotation.element.tagName}`)
+        lines.push('')
+        lines.push(`**Selector:** \`${annotation.element.selector}\``)
+        lines.push(`**Annotated at:** ${time}`)
+        lines.push('')
+        lines.push(annotation.note)
+        lines.push('')
+
+        // Add element details
+        if (annotation.element.id) {
+          lines.push(`- **ID:** ${annotation.element.id}`)
+        }
+        if (annotation.element.classList.length > 0) {
+          lines.push(`- **Classes:** ${annotation.element.classList.join(', ')}`)
+        }
+        if (Object.keys(annotation.element.dataAttributes).length > 0) {
+          lines.push(`- **Data attributes:** ${JSON.stringify(annotation.element.dataAttributes)}`)
+        }
+        lines.push('')
+        lines.push('---')
+        lines.push('')
+      }
+    }
+
+    // Summary section
+    lines.push('## Summary')
+    lines.push('')
+    lines.push('| Category | Count |')
+    lines.push('|----------|-------|')
+    for (const [category, categoryAnnotations] of byCategory) {
+      const info = CATEGORY_INFO[category]
+      lines.push(`| ${info.emoji} ${info.label} | ${categoryAnnotations.length} |`)
+    }
+    lines.push('')
+
+    const markdown = lines.join('\n')
+    onExport?.(markdown, annotations)
+    return markdown
+  }, [annotations, sessionName, onExport])
+
+  // Calculate stats
+  const stats = useMemo(() => {
+    const byCategory: Record<AnnotationCategory, number> = {
+      physics: 0,
+      layout: 0,
+      accessibility: 0,
+      performance: 0,
+      ux: 0,
+      bug: 0,
+      suggestion: 0,
+      other: 0,
+    }
+
+    for (const annotation of annotations) {
+      byCategory[annotation.category]++
+    }
+
+    return {
+      total: annotations.length,
+      byCategory,
+    }
+  }, [annotations])
+
+  return {
+    annotations,
+    addAnnotation,
+    removeAnnotation,
+    updateAnnotation,
+    clearAnnotations,
+    exportToMarkdown,
+    getByCategory,
+    stats,
+  }
+}
+
+// Export category info for use in UI
+export { CATEGORY_INFO }

--- a/packages/hud/src/inspector/useElementInspector.ts
+++ b/packages/hud/src/inspector/useElementInspector.ts
@@ -1,0 +1,393 @@
+/**
+ * Element Inspector Hook
+ *
+ * Provides element inspection capabilities for the HUD.
+ * Detects hovered elements, extracts React component info from fiber,
+ * and generates CSS selectors.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+
+/**
+ * Information about an inspected element
+ */
+export interface InspectedElement {
+  /** The DOM element being inspected */
+  element: HTMLElement
+  /** React component name (if found in fiber) */
+  componentName: string | null
+  /** Generated CSS selector */
+  selector: string
+  /** Element's bounding rect */
+  rect: DOMRect
+  /** Tag name */
+  tagName: string
+  /** Element's id attribute */
+  id: string | null
+  /** Element's class list */
+  classList: string[]
+  /** Data attributes */
+  dataAttributes: Record<string, string>
+  /** Sigil HUD attribute (if present) */
+  sigilAttribute: string | null
+}
+
+/**
+ * Options for the inspector hook
+ */
+export interface UseElementInspectorOptions {
+  /** Elements to exclude from inspection (e.g., the HUD itself) */
+  excludeSelectors?: string[]
+  /** Callback when an element is inspected */
+  onInspect?: (element: InspectedElement) => void
+  /** Callback when inspection mode ends */
+  onExit?: () => void
+}
+
+/**
+ * Return type for useElementInspector
+ */
+export interface UseElementInspectorReturn {
+  /** Whether inspector mode is active */
+  isInspecting: boolean
+  /** Start inspector mode */
+  startInspecting: () => void
+  /** Stop inspector mode */
+  stopInspecting: () => void
+  /** Toggle inspector mode */
+  toggleInspecting: () => void
+  /** Currently hovered element info */
+  hoveredElement: InspectedElement | null
+  /** Currently selected (clicked) element info */
+  selectedElement: InspectedElement | null
+  /** Clear selection */
+  clearSelection: () => void
+}
+
+// React internal key for accessing fiber
+const FIBER_KEYS = [
+  '__reactFiber$',
+  '__reactInternalInstance$',
+  '_reactRootContainer',
+]
+
+/**
+ * Extract React component name from a DOM element's fiber
+ */
+function getReactComponentName(element: HTMLElement): string | null {
+  // Try to find React fiber key on the element
+  for (const key of Object.keys(element)) {
+    for (const fiberKey of FIBER_KEYS) {
+      if (key.startsWith(fiberKey)) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const fiber = (element as any)[key]
+          if (fiber) {
+            // Walk up the fiber tree to find a named component
+            let current = fiber
+            while (current) {
+              const name = getComponentNameFromFiber(current)
+              if (name && !isInternalComponent(name)) {
+                return name
+              }
+              current = current.return
+            }
+          }
+        } catch {
+          // Fiber access failed, continue
+        }
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Get component name from a fiber node
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getComponentNameFromFiber(fiber: any): string | null {
+  if (!fiber) return null
+
+  // Function component or class component
+  if (fiber.type) {
+    if (typeof fiber.type === 'function') {
+      return fiber.type.displayName || fiber.type.name || null
+    }
+    if (typeof fiber.type === 'string') {
+      return null // This is a DOM element, not a component
+    }
+    // ForwardRef, memo, etc.
+    if (fiber.type.displayName) {
+      return fiber.type.displayName
+    }
+    if (fiber.type.render?.displayName || fiber.type.render?.name) {
+      return fiber.type.render.displayName || fiber.type.render.name
+    }
+  }
+
+  return null
+}
+
+/**
+ * Check if a component name is internal (should be skipped)
+ */
+function isInternalComponent(name: string): boolean {
+  // Skip React internal components and common wrappers
+  const internalPatterns = [
+    /^Fragment$/,
+    /^Suspense$/,
+    /^Provider$/,
+    /^Consumer$/,
+    /^Context\./,
+    /^ForwardRef\(/,
+    /^Memo\(/,
+    /^__/,
+  ]
+  return internalPatterns.some((pattern) => pattern.test(name))
+}
+
+/**
+ * Generate a CSS selector for an element
+ */
+function getSelector(element: HTMLElement): string {
+  // If element has an id, use that
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`
+  }
+
+  // If element has data-testid, use that
+  const testId = element.getAttribute('data-testid')
+  if (testId) {
+    return `[data-testid="${CSS.escape(testId)}"]`
+  }
+
+  // If element has data-sigil-hud, use that
+  const sigilAttr = element.getAttribute('data-sigil-hud')
+  if (sigilAttr) {
+    return `[data-sigil-hud="${CSS.escape(sigilAttr)}"]`
+  }
+
+  // Build a path selector
+  const path: string[] = []
+  let current: HTMLElement | null = element
+
+  while (current && current !== document.body) {
+    let selector = current.tagName.toLowerCase()
+
+    if (current.id) {
+      selector = `#${CSS.escape(current.id)}`
+      path.unshift(selector)
+      break
+    }
+
+    // Add class names (first 2 non-utility classes)
+    const meaningfulClasses = Array.from(current.classList)
+      .filter((c) => !isUtilityClass(c))
+      .slice(0, 2)
+
+    if (meaningfulClasses.length > 0) {
+      selector += meaningfulClasses.map((c) => `.${CSS.escape(c)}`).join('')
+    }
+
+    // Add nth-child if needed for uniqueness
+    const parent = current.parentElement
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(
+        (child) => child.tagName === current!.tagName
+      )
+      if (siblings.length > 1) {
+        const index = siblings.indexOf(current) + 1
+        selector += `:nth-of-type(${index})`
+      }
+    }
+
+    path.unshift(selector)
+    current = current.parentElement
+  }
+
+  return path.join(' > ')
+}
+
+/**
+ * Check if a class name looks like a utility class (Tailwind, etc.)
+ */
+function isUtilityClass(className: string): boolean {
+  const utilityPatterns = [
+    /^(p|m|w|h|min|max)(-|$)/,
+    /^(flex|grid|block|inline|hidden)$/,
+    /^(bg|text|border|rounded|shadow)-/,
+    /^(absolute|relative|fixed|sticky)$/,
+    /^(overflow|z)-/,
+    /^(gap|space)-/,
+    /^(font|leading|tracking)-/,
+    /^(opacity|cursor|pointer-events)-/,
+  ]
+  return utilityPatterns.some((pattern) => pattern.test(className))
+}
+
+/**
+ * Extract element information
+ */
+function extractElementInfo(element: HTMLElement): InspectedElement {
+  const dataAttributes: Record<string, string> = {}
+  for (const attr of Array.from(element.attributes)) {
+    if (attr.name.startsWith('data-')) {
+      dataAttributes[attr.name] = attr.value
+    }
+  }
+
+  return {
+    element,
+    componentName: getReactComponentName(element),
+    selector: getSelector(element),
+    rect: element.getBoundingClientRect(),
+    tagName: element.tagName.toLowerCase(),
+    id: element.id || null,
+    classList: Array.from(element.classList),
+    dataAttributes,
+    sigilAttribute: element.getAttribute('data-sigil-hud'),
+  }
+}
+
+/**
+ * Hook for element inspection
+ */
+export function useElementInspector(
+  options: UseElementInspectorOptions = {}
+): UseElementInspectorReturn {
+  const { excludeSelectors = ['[data-sigil-hud]'], onInspect, onExit } = options
+
+  const [isInspecting, setIsInspecting] = useState(false)
+  const [hoveredElement, setHoveredElement] = useState<InspectedElement | null>(null)
+  const [selectedElement, setSelectedElement] = useState<InspectedElement | null>(null)
+
+  const isInspectingRef = useRef(isInspecting)
+  isInspectingRef.current = isInspecting
+
+  // Check if element should be excluded from inspection
+  const shouldExclude = useCallback(
+    (element: HTMLElement): boolean => {
+      return excludeSelectors.some((selector) => {
+        try {
+          return element.closest(selector) !== null
+        } catch {
+          return false
+        }
+      })
+    },
+    [excludeSelectors]
+  )
+
+  // Handle mouse move
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isInspectingRef.current) return
+
+      const target = e.target as HTMLElement
+      if (!target || target === document.body || target === document.documentElement) {
+        setHoveredElement(null)
+        return
+      }
+
+      if (shouldExclude(target)) {
+        setHoveredElement(null)
+        return
+      }
+
+      const info = extractElementInfo(target)
+      setHoveredElement(info)
+    },
+    [shouldExclude]
+  )
+
+  // Handle click to select element
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (!isInspectingRef.current) return
+
+      const target = e.target as HTMLElement
+      if (!target || shouldExclude(target)) return
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      const info = extractElementInfo(target)
+      setSelectedElement(info)
+      onInspect?.(info)
+    },
+    [shouldExclude, onInspect]
+  )
+
+  // Handle escape key
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!isInspectingRef.current) return
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setIsInspecting(false)
+        setHoveredElement(null)
+        onExit?.()
+      }
+    },
+    [onExit]
+  )
+
+  // Start inspecting
+  const startInspecting = useCallback(() => {
+    setIsInspecting(true)
+    setSelectedElement(null)
+  }, [])
+
+  // Stop inspecting
+  const stopInspecting = useCallback(() => {
+    setIsInspecting(false)
+    setHoveredElement(null)
+    onExit?.()
+  }, [onExit])
+
+  // Toggle inspecting
+  const toggleInspecting = useCallback(() => {
+    if (isInspectingRef.current) {
+      stopInspecting()
+    } else {
+      startInspecting()
+    }
+  }, [startInspecting, stopInspecting])
+
+  // Clear selection
+  const clearSelection = useCallback(() => {
+    setSelectedElement(null)
+  }, [])
+
+  // Set up event listeners
+  useEffect(() => {
+    if (!isInspecting) return
+
+    // Use capture phase to get events before they're handled by other listeners
+    document.addEventListener('mousemove', handleMouseMove, true)
+    document.addEventListener('click', handleClick, true)
+    document.addEventListener('keydown', handleKeyDown, true)
+
+    // Add cursor style to body
+    document.body.style.cursor = 'crosshair'
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove, true)
+      document.removeEventListener('click', handleClick, true)
+      document.removeEventListener('keydown', handleKeyDown, true)
+      document.body.style.cursor = ''
+    }
+  }, [isInspecting, handleMouseMove, handleClick, handleKeyDown])
+
+  return {
+    isInspecting,
+    startInspecting,
+    stopInspecting,
+    toggleInspecting,
+    hoveredElement,
+    selectedElement,
+    clearSelection,
+  }
+}

--- a/packages/hud/src/wagmi/index.ts
+++ b/packages/hud/src/wagmi/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Wagmi integration for Sigil HUD
+ *
+ * Drop-in replacement for wagmi's useAccount that respects Lens impersonation.
+ *
+ * @example
+ * ```tsx
+ * // Replace: import { useAccount } from 'wagmi'
+ * import { useAccount } from '@thehoneyjar/sigil-hud/wagmi'
+ *
+ * function MyComponent() {
+ *   const { address, realAddress, isImpersonating } = useAccount()
+ *   // address = effective address (impersonated if lens enabled)
+ *   // realAddress = real wallet (for signing)
+ * }
+ * ```
+ */
+
+import { useAccount as useWagmiAccount } from 'wagmi'
+import type { Address } from 'viem'
+
+/**
+ * Return type for useAccount hook
+ */
+export interface LensAwareAccountReturn {
+  /** Address for reads (impersonated if lens enabled, otherwise real) */
+  address: Address | undefined
+  /** The user's real connected address (always available for signing) */
+  realAddress: Address | undefined
+  /** Whether currently impersonating another address */
+  isImpersonating: boolean
+  /** The impersonated address (if any) */
+  impersonatedAddress: Address | null
+  /** Whether the wallet is connected */
+  isConnected: boolean
+  /** Connector info */
+  connector: ReturnType<typeof useWagmiAccount>['connector']
+  /** Chain ID */
+  chainId: ReturnType<typeof useWagmiAccount>['chainId']
+  /** Connection status */
+  status: ReturnType<typeof useWagmiAccount>['status']
+}
+
+// Attempt to import lens store - may not be installed
+let useLensStore: (() => { impersonatedAddress: Address | null; enabled: boolean }) | null = null
+
+try {
+  // Dynamic require to handle optional dependency
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const lensModule = require('@thehoneyjar/sigil-lens')
+  useLensStore = lensModule.useLensStore
+} catch {
+  // sigil-lens not installed, will fall back to standard wagmi behavior
+}
+
+/**
+ * Drop-in replacement for wagmi's useAccount.
+ *
+ * When @thehoneyjar/sigil-lens is installed and Lens is enabled,
+ * returns the impersonated address for reads while preserving
+ * the real address for signing.
+ *
+ * @example
+ * ```tsx
+ * // Replace: import { useAccount } from 'wagmi'
+ * import { useAccount } from '@thehoneyjar/sigil-hud/wagmi'
+ *
+ * function MyComponent() {
+ *   const { address, realAddress, isImpersonating } = useAccount()
+ *
+ *   // Use `address` for read operations (queries, display)
+ *   const { data } = useBalance({ address })
+ *
+ *   // Use `realAddress` for write operations (signing)
+ *   const { writeContract } = useWriteContract()
+ * }
+ * ```
+ */
+export function useAccount(): LensAwareAccountReturn {
+  const wagmiAccount = useWagmiAccount()
+
+  // If sigil-lens is available, check for impersonation
+  if (useLensStore) {
+    try {
+      const lensState = useLensStore()
+      const isImpersonating = lensState.enabled && lensState.impersonatedAddress !== null
+
+      return {
+        ...wagmiAccount,
+        address: isImpersonating ? lensState.impersonatedAddress! : wagmiAccount.address,
+        realAddress: wagmiAccount.address,
+        isImpersonating,
+        impersonatedAddress: lensState.impersonatedAddress,
+      }
+    } catch {
+      // If lens store errors, fall back to standard behavior
+    }
+  }
+
+  // Fallback: no lens, just return wagmi account with additional fields
+  return {
+    ...wagmiAccount,
+    realAddress: wagmiAccount.address,
+    isImpersonating: false,
+    impersonatedAddress: null,
+  }
+}
+
+/**
+ * Simple hook to get the effective address for reads.
+ *
+ * This is a convenience wrapper around useAccount that returns only the address.
+ * Use when you only need the effective address and don't need signing capabilities.
+ *
+ * @example
+ * ```tsx
+ * import { useEffectiveAddress } from '@thehoneyjar/sigil-hud/wagmi'
+ *
+ * function BalanceDisplay() {
+ *   const address = useEffectiveAddress()
+ *   const { data } = useBalance({ address })
+ *   return <div>{data?.formatted}</div>
+ * }
+ * ```
+ */
+export function useEffectiveAddress(): Address | undefined {
+  const { address } = useAccount()
+  return address
+}
+
+/**
+ * Re-export useLensAwareAccount for backward compatibility
+ * with existing code using @thehoneyjar/sigil-lens/wagmi
+ */
+export const useLensAwareAccount = useAccount

--- a/packages/hud/tsup.config.ts
+++ b/packages/hud/tsup.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    'wagmi/index': 'src/wagmi/index.ts',
+  },
   format: ['esm'],
   dts: true,
   clean: true,
   external: [
     'react',
+    'wagmi',
+    'viem',
     '@thehoneyjar/sigil-anchor',
     '@thehoneyjar/sigil-fork',
     '@thehoneyjar/sigil-simulation',
@@ -14,4 +19,5 @@ export default defineConfig({
     '@thehoneyjar/sigil-diagnostics',
   ],
   treeshake: true,
+  sourcemap: true,
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
 
   packages/diagnostics:
     dependencies:
-      '@sigil/anchor':
+      '@thehoneyjar/sigil-anchor':
         specifier: workspace:*
         version: link:../anchor
       react:
@@ -79,22 +79,13 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0(@types/react@18.2.45)(react@18.2.0)
     optionalDependencies:
-      '@sigil/anchor':
-        specifier: workspace:*
+      '@thehoneyjar/sigil-anchor':
+        specifier: ^4.3.0
         version: link:../anchor
-      '@sigil/diagnostics':
-        specifier: workspace:*
-        version: link:../diagnostics
-      '@sigil/fork':
-        specifier: workspace:*
-        version: link:../fork
-      '@sigil/lens':
-        specifier: workspace:*
-        version: link:../lens
-      '@sigil/simulation':
-        specifier: workspace:*
-        version: link:../simulation
     devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.11.0
       '@types/react':
         specifier: ^18.0.0
         version: 18.2.45
@@ -107,6 +98,12 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.3.3
+      viem:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.3.3)
+      wagmi:
+        specifier: ^2.0.0
+        version: 2.0.0(@tanstack/react-query@5.0.0-beta.23)(@types/react@18.2.45)(react@18.2.0)(typescript@5.3.3)(viem@2.0.0)
 
   packages/lens:
     dependencies:
@@ -200,7 +197,7 @@ importers:
 
   packages/simulation:
     dependencies:
-      '@sigil/fork':
+      '@thehoneyjar/sigil-fork':
         specifier: workspace:*
         version: link:../fork
     devDependencies:
@@ -503,7 +500,7 @@ packages:
       eth-rpc-errors: 4.0.2
       json-rpc-engine: 6.1.0
       keccak: 3.0.4
-      preact: 10.19.3
+      preact: 10.24.2
       qs: 6.14.1
       rxjs: 6.6.7
       sha.js: 2.4.12
@@ -1658,7 +1655,7 @@ packages:
   /@scure/bip32@1.7.0:
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
     dev: true
@@ -5886,7 +5883,6 @@ packages:
   /preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
     dev: true
-    optional: true
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}


### PR DESCRIPTION
## Summary

- **Sprint 1: Package Publishing** - Fixes #41, #45: Remove Tailwind, fix workspace dependencies, add npm publish workflow
- **Sprint 2: Wagmi Integration** - Fixes #47: Add `useAccount` hook with Lens impersonation support
- **Sprint 3: JsonPreview Component** - Fixes #46: Sticky copy header, no horizontal scroll, syntax highlighting
- **Sprint 4: Element Inspector** - Agentation-inspired element inspection with annotation session and markdown export

## Test plan

- [ ] Build passes: `pnpm --filter @thehoneyjar/sigil-hud build`
- [ ] Verify dist output includes `index.js`, `index.d.ts`, `wagmi/index.js`, `wagmi/index.d.ts`
- [ ] Test wagmi hook import: `import { useAccount } from '@thehoneyjar/sigil-hud/wagmi'`
- [ ] Test JsonPreview renders with sticky header
- [ ] Test ElementInspector in HUD panel

## Changes

| File | Change |
|------|--------|
| `.github/workflows/publish-hud.yml` | NEW: npm publish workflow on `hud-v*` tags |
| `packages/hud/package.json` | Fix deps, add wagmi subpath export |
| `packages/hud/tsup.config.ts` | Multi-entry for wagmi subpath |
| `packages/hud/src/wagmi/index.ts` | NEW: Lens-aware useAccount hook |
| `packages/hud/src/components/JsonPreview.tsx` | NEW: JSON viewer with sticky copy |
| `packages/hud/src/inspector/*` | NEW: Element inspector module |
| `packages/hud/src/components/HudTrigger.tsx` | Remove Tailwind, use inline styles |
| `packages/hud/src/components/HudPanel.tsx` | Remove Tailwind, use inline styles |

🤖 Generated with [Claude Code](https://claude.com/claude-code)